### PR TITLE
refactor: Replace resolveSync with resolveSyncNonBlocking for better performance

### DIFF
--- a/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/ResolveResultViewModel.kt
+++ b/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/ResolveResultViewModel.kt
@@ -72,13 +72,13 @@ open class ResolveResultViewModel(application: Application) : AndroidViewModel(a
     }
 
     /**
-     * 同步获取解析结果
+     * 同步非阻塞获取解析结果
      */
-    fun resolveSync(host: String?): HTTPDNSResult? {
+    fun resolveSyncNonBlocking(host: String?): HTTPDNSResult? {
         if (TextUtils.isEmpty(host)) {
             return null
         }
-        return httpDnsService?.getHttpDnsResultForHostSync(host, RequestIpType.auto)
+        return httpDnsService?.getHttpDnsResultForHostSyncNonBlocking(host, RequestIpType.auto)
     }
 
     /**

--- a/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/exoplayer/ExoPlayerCaseViewModel.kt
+++ b/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/exoplayer/ExoPlayerCaseViewModel.kt
@@ -36,7 +36,7 @@ class ExoPlayerCaseViewModel(application: Application) : ResolveResultViewModel(
                 override fun lookup(hostname: String): List<InetAddress> {
                     val currMills = System.currentTimeMillis()
                     val inetAddresses = mutableListOf<InetAddress>()
-                    resolveSync(host.value!!)?.apply {
+                    resolveSyncNonBlocking(host.value!!)?.apply {
                         showResolveResult(this, currMills)
                         processDnsResult(this, inetAddresses)
                         log(

--- a/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/ipconn/IPConnCaseViewModel.kt
+++ b/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/ipconn/IPConnCaseViewModel.kt
@@ -57,7 +57,7 @@ class IPConnCaseViewModel(application: Application) : ResolveResultViewModel(app
 
         val currMill = System.currentTimeMillis()
         //解析
-        val result = httpDnsService?.getHttpDnsResultForHostSync(host, RequestIpType.auto)?.apply {
+        val result = httpDnsService?.getHttpDnsResultForHostSyncNonBlocking(host, RequestIpType.auto)?.apply {
             log(this@IPConnCaseViewModel, this.toString())
             showResolveResult(this, currMill)
         }

--- a/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/okhttp/OkHttpCaseViewModel.kt
+++ b/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/okhttp/OkHttpCaseViewModel.kt
@@ -47,7 +47,7 @@ class OkHttpCaseViewModel(application: Application) : ResolveResultViewModel(app
                 override fun lookup(hostname: String): List<InetAddress> {
                     val currMills = System.currentTimeMillis()
                     val inetAddresses = mutableListOf<InetAddress>()
-                    resolveSync(host.value)?.apply {
+                    resolveSyncNonBlocking(host.value)?.apply {
                         showResolveResult(this, currMills)
                         processDnsResult(this, inetAddresses)
                         log(

--- a/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/webview/WebViewCaseFragment.kt
+++ b/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/webview/WebViewCaseFragment.kt
@@ -184,7 +184,7 @@ class WebViewCaseFragment : BaseFragment<WebViewCaseBinding>() {
             val url = URL(path)
             val currMill = System.currentTimeMillis()
             val result =
-                viewModel.httpDnsService?.getHttpDnsResultForHostSync(url.host, RequestIpType.auto)
+                viewModel.httpDnsService?.getHttpDnsResultForHostSyncNonBlocking(url.host, RequestIpType.auto)
                     ?.apply {
                         log(this@WebViewCaseFragment, this.toString())
                         if (url.host == viewModel.host.value) {

--- a/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/webview/WebViewOkHttpCaseFragment.kt
+++ b/httpdns_android_demo/src/main/java/com/alibaba/httpdns/android/demo/practice/webview/WebViewOkHttpCaseFragment.kt
@@ -68,7 +68,7 @@ class WebViewOkHttpCaseFragment : BaseFragment<WebViewCaseBinding>() {
                 override fun lookup(hostname: String): List<InetAddress> {
                     val currMills = System.currentTimeMillis()
                     val inetAddresses = mutableListOf<InetAddress>()
-                    viewModel.resolveSync(hostname)?.apply {
+                    viewModel.resolveSyncNonBlocking(hostname)?.apply {
                         if (hostname == viewModel.host.value) {
                             viewModel.showResolveResult(this, currMills)
                         }


### PR DESCRIPTION
- Rename ResolveResultViewModel.resolveSync() to resolveSyncNonBlocking()
- Update all DNS resolution calls to use getHttpDnsResultForHostSyncNonBlocking
- Improve app responsiveness by avoiding blocking DNS calls
- Affected modules: WebView, OkHttp, ExoPlayer, IP Connection practices

Files changed:
- ResolveResultViewModel.kt: Method rename and implementation update
- WebViewCaseFragment.kt: Direct SDK call update
- WebViewOkHttpCaseFragment.kt: Method call update
- ExoPlayerCaseViewModel.kt: Method call update
- OkHttpCaseViewModel.kt: Method call update
- IPConnCaseViewModel.kt: Direct SDK call update